### PR TITLE
CDN support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ Then run this command:
 hexo emojis install
 ```
 
+Another way, you can simply add cdn url like this:
+
+```
+# hexo-tag-emojis plugin configuration
+emojis:
+  cdn: http://cdn.staticfile.org/emojify.js/0.9.0/emojis
+```
+In this way, nothing will install into you blog, all images are from the CDN server,
+This is particularly useful for the blog hosted on github,
+because github is really slow for images
+
+
 ## Usage
 
 #### Method 1 - Inline emoji

--- a/emojiCommands.js
+++ b/emojiCommands.js
@@ -6,10 +6,15 @@ var emojiCommands = module.exports = function(hexo) {
     emojiCommands.hexo = hexo;
     emojiCommands.emojiConfig = hexo.config.emojis || false;
     emojiCommands.emojiImageDir = emojiCommands.emojiConfig.image_dir || false;
+    emojiCommands.emojisCDN = emojiCommands.emojiConfig.cdn || false;
     emojiCommands.sourceDir = __dirname + '/source/images/emojis';
     emojiCommands.deployDir = hexo.base_dir + 'source/' + emojiCommands.emojiImageDir;
 
-    if (!emojiCommands.emojiConfig || !emojiCommands.emojiImageDir) {
+    if (!emojiCommands.emojiConfig ) {
+        throw new Error('Emoji configuration was not found.');
+    }
+    
+    if( !emojiCommands.emojiImageDir && !emojiCommands.emojisCDN){
         throw new Error('Emoji configuration was not found.');
     }
 

--- a/index.js
+++ b/index.js
@@ -3,9 +3,11 @@ var htmlTag = hexo.util.html_tag,
     emojiCommands = require('./emojiCommands')(hexo),
     rootPath = hexo.config.root,
     emojiConfig = hexo.config.emojis || false,
-    emojiImageDir = emojiConfig.image_dir || false;
+    emojiImageDir = emojiConfig.image_dir || false,
+    emojiCDN = emojiConfig.cdn || false,
+    emojiPrefix = emojiCDN ? emojiCDN : rootPath+emojiImageDir,
     defaultEmojiSize = 20;
-
+    
 /**
  * Emoji commands for Hexo.
  * Use `install` option to copy emoji assets on your Hexo blog.
@@ -53,7 +55,7 @@ hexo.extend.tag.register('emoji', function(args, content){
     var classes = args[2] || "";
     var imgAttr = {};
 
-    if (!emojiConfig || !emojiImageDir) {
+    if (!emojiConfig || !emojiPrefix) {
         throw new Error('Emoji configuration was not found.');
     }
 
@@ -61,7 +63,7 @@ hexo.extend.tag.register('emoji', function(args, content){
     classes.push('emoji');
     classes.push('nofancybox');
 
-    imgAttr.src = rootPath+emojiImageDir+'/'+emojiName+'.png';
+    imgAttr.src = emojiPrefix +'/'+emojiName+'.png';
     imgAttr.width = emojiSize;
     imgAttr.height = emojiSize;
     imgAttr.class = classes.join(' ');
@@ -84,7 +86,7 @@ hexo.extend.tag.register('emoji-block', function(args, content) {
     var classes = args[1] || "";
     var imgAttr = {};
 
-    if (!emojiConfig || !emojiImageDir) {
+    if (!emojiConfig || !emojiPrefix) {
         throw new Error('Emoji configuration was not found.');
     }
 
@@ -100,7 +102,7 @@ hexo.extend.tag.register('emoji-block', function(args, content) {
     var emojifiedContent = content.replace(/:(.*?):/g, function(match) {
         match = match.replace(/:/g, ''); // :something: => something
         imgAttr.title = match;
-        imgAttr.src = rootPath+emojiImageDir+'/'+match+'.png';
+        imgAttr.src = emojiPrefix +'/'+match+'.png';
 
         return htmlTag('img', imgAttr);
     });


### PR DESCRIPTION
Another way, you can simply add cdn url like this:

```
# hexo-tag-emojis plugin configuration
emojis:
  cdn: http://cdn.staticfile.org/emojify.js/0.9.0/emojis
```

In this way, nothing will install into you blog, all images are from the CDN server,
This is particularly useful for the blog hosted on github,
because github is really slow for images
